### PR TITLE
Fix for fastboot

### DIFF
--- a/app/initializers/offline.js
+++ b/app/initializers/offline.js
@@ -4,6 +4,7 @@ export function initialize() {
   const application = arguments[1] || arguments[0];
 
   // apply config to global Offline
+  window.Offline = window.Offline || {};
   window.Offline.options = config.emberOffline;
 
   application.register('offline:main', window.Offline, { instantiate: false });


### PR DESCRIPTION
The problem occurs when this initializer tries to run in fastboot

```
TypeError: Cannot set property 'options' of undefined
at Object.initialize (/var/app/current/intranet-beta/tmp/broccoli_merge_trees-output_path-kxpnqEYE.tmp/assets/doctify/initializers/offline.js:12:1)
```