### PR TITLE
Allow turning off warning UI from offline.js

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -2,13 +2,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return {
-    emberOffline: {
-      themes: {
-        theme: 'default',
-        indicator: false,
-        language: 'english'
-      }
-    }
-  };
+  return {};
 };


### PR DESCRIPTION
Since the `included` hook [configures the default theme if none is configured](https://github.com/ahmadsoe/ember-offline/blob/master/index.js#L29-L35), also defining it in the add-on config prevents being able to opt-out of Offline.js default "flash-style" messages (which is not shown if the css is not added to the bundle).

This commit modifies the configuration to be empty so that consumers of the add-on can opt-out of the flash messages by putting `emberOffline: { themes: {} }` in their `config/environment.js`.

```js
emberOffline: {
    // Disable showing the Offline.js banner
    themes: {}
}
```